### PR TITLE
Update gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -108,10 +108,10 @@ function deploy() {
 }
 
 function startwatch() {
-	watch(baseDir  + '/**/' + preprocessor + '/**/*', styles);
-	watch(baseDir  + '/**/*.{' + imageswatch + '}', images);
+	watch(baseDir  + '/' + preprocessor + '/**/*', styles);
+	watch(baseDir  + '/images/src/*.{' + imageswatch + '}', images);
 	watch(baseDir  + '/**/*.{' + fileswatch + '}').on('change', browserSync.reload);
-	watch([baseDir + '/**/*.js', '!' + paths.scripts.dest + '/*.min.js'], scripts);
+	watch([baseDir + '/js/*.js', '!' + paths.scripts.dest + '/*.min.js'], scripts);
 }
 
 exports.browsersync = browsersync;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,7 @@ function deploy() {
 function startwatch() {
 	watch(baseDir  + '/' + preprocessor + '/**/*', styles);
 	watch(baseDir  + '/images/src/*.{' + imageswatch + '}', images);
-	watch(baseDir  + '/**/*.{' + fileswatch + '}').on('change', browserSync.reload);
+	watch(baseDir  + '/*.{' + fileswatch + '}').on('change', browserSync.reload);
 	watch([baseDir + '/js/*.js', '!' + paths.scripts.dest + '/*.min.js'], scripts);
 }
 


### PR DESCRIPTION
Get rid of recursive paths in 'startwatch' func for the purpose of better compilation performance.
Tested on Windows 10 2004 (19041.388) and under WSL2 (Ubuntu 18.04) - both has compilation performance boost.

Before:
Compilation times keep increasing on every startwatch run iteration.