### PR TITLE
Fix use on new debian based os versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
 	"main": "index.js",
 	"author": "WebDesign Master",
 	"license": "ISC",
+	"scripts": {
+		"start": "gulp",
+		"build": "gulp build"
+	},
 	"devDependencies": {
 		"@babel/core": "^7.13.15",
 		"@babel/preset-env": "^7.13.15",


### PR DESCRIPTION
Make gulp default via ```npm{yarn} start ``` and gulp build via ```npm{yarn} build``` works   without install gulp by apt package manager