### PR TITLE
Fix webpack break in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,7 +72,7 @@ function scripts() {
 					})
 				]
 			},
-		}, webpack)).on('error', function handleError() {
+		}, webpack)).on('error', (err) => {
 			this.emit('end')
 		})
 		.pipe(concat('app.min.js'))


### PR DESCRIPTION
Found a small issue in gulpfile.js. When I run task `scripts` with a typo in app.js I got an error like `webpack 5.66.0 compiled with 1 error`.  After this the task stop to track changes in app.js.

Fix from here: https://github.com/shama/webpack-stream/issues/34#issuecomment-478602446